### PR TITLE
Update Sphinx==2.4.4 to 3.0.4

### DIFF
--- a/Documentation/sphinx/requirements.txt
+++ b/Documentation/sphinx/requirements.txt
@@ -1,3 +1,3 @@
 docutils
-Sphinx==2.4.4
+Sphinx==3.0.4
 sphinx_rtd_theme


### PR DESCRIPTION
Affected versions of this package are vulnerable to Cross-site Scripting (XSS). Passing HTML from untrusted sources - even after sanitizing it - to one of jQuery's DOM manipulation methods (i.e. .html(), .append(), and others) may execute untrusted code.